### PR TITLE
Removing reference to UpdateRemoteJob#actions - I removed it in #1

### DIFF
--- a/app/jobs/github/check_suites/update_remote_job.rb
+++ b/app/jobs/github/check_suites/update_remote_job.rb
@@ -25,8 +25,7 @@ class Github::CheckSuites::UpdateRemoteJob < ApplicationJob
           annotations: annotations[0..49],
           title: output_title,
           summary: output_summary
-        },
-        actions: actions
+        }
       }
     )
     @github_check_suite.update!(check_run_id: @created_check_run.id)


### PR DESCRIPTION
As part of https://github.com/TypoCI/Marketplace-App/pull/1 I removed `UpdateRemoteJob#actions` because it was just returning an empty array.

I forgot to remove the reference to it (and also the tests didn't pick up on it 👀). So removing the reference.