### PR TITLE
Not counting uninstalled apps towards MRR

### DIFF
--- a/app/jobs/github/installation/update_marketplace_purchase_job.rb
+++ b/app/jobs/github/installation/update_marketplace_purchase_job.rb
@@ -50,6 +50,8 @@ class Github::Installation::UpdateMarketplacePurchaseJob < ApplicationJob
   end
 
   def mrr_in_cents
+    return 0 unless marketplace_plan[:marketplace_purchase][:is_installed]
+
     if marketplace_plan[:marketplace_purchase][:billing_cycle] == "monthly"
       marketplace_plan[:marketplace_purchase][:plan][:monthly_price_in_cents]
     else


### PR DESCRIPTION
GitHub allows users to keep apps installed (and has a `next_billing_date`) even if they're installed. So recalculating MRR differently accounting for that.